### PR TITLE
Refactor release workflow to simplify configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,119 +1,14 @@
-# Take == dependencies in pyproject.toml (or equivalent) and relax them
-# according to conda environment yaml files and rules for semantic versioning,
-# then make a pypi release.
-# For full docs cf. .support/update_pyproject_dependencies.py'
-# Usage:
-#   on:
-#     release:
-#       types: [published]
-
-name: Pyproject Release
+name: Release
 
 on:
-  workflow_call:
-    inputs:
-      python-version:
-        type: string
-        description: 'Cached python versions'
-        default: '3.12'
-        required: false
-      env-files:
-        type: string
-        description: 'Conda environment(S)'
-        default: .ci_support/environment.yml
-        required: false
-      input-toml:
-        type: string
-        description: 'Input TOML file with `project.dependencies` and `==` pinned dependencies.'
-        default: 'pyproject.toml'
-        required: false
-      lower-bound-yaml:
-        type: string
-        description: 'Optional YAML conda environment file with lower bounds for select dependencies.'
-        default: 'none'
-        required: false
-      upper-bound-yaml:
-        type: string
-        description: 'Optional YAML conda environment file with upper bounds for select dependencies.'
-        default: 'none'
-        required: false
-      semantic-upper-bound:
-        type: string
-        description: 'Upper bound policy for semantically versioned dependencies.'
-        default: 'patch'
-        required: false
-      always-pin-unstable:
-        type: string
-        description: 'Whether to always pin unstable dependencies (0.Y.Z) all the way to patch.'
-        default: 'yes'
-        required: false
-      output-toml:
-        type: string
-        description: 'Optional output destination for toml with updated dependency versions.'
-        default: 'none'
-        required: false
-      pypi-to-conda-name-map-file:
-        type: string
-        description: 'Optional JSON file to remap pypi package names in the toml file(s) to conda package names in the yaml file(s).'
-        default: $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
-        required: false
-      pyyaml-version:
-        type: string
-        description: 'Version of pyyaml to install'
-        default: '6.0.1'
-        required: false
-      toml-version:
-        type: string
-        description: 'Version of toml to install'
-        default: '0.10.2'
-        required: false
-      publish-to-pypi:
-        type: boolean
-        description: 'Whether to actually publish the result. Turning it off is useful for debugging new builds.'
-        default: true
-        required: false
-      runner:
-        type: string
-        description: 'The main runner to use everywhere'
-        default: 'ubuntu-22.04'
-        required: false
+#  pull_request:
+  release:
+    types: [ published ]
 
 jobs:
-  pypi-release:
-    runs-on: ${{ inputs.runner }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: pyiron/actions/cached-miniforge@actions-4.0.8
-      with:
-        python-version: ${{ inputs.python-version }}
-        env-files: ${{ inputs.env-files }}
-    - uses: ./.github/actions/update-pyproject-dependencies
-      with:
-        input-toml: ${{ inputs.input-toml }}
-        lower-bound-yaml: ${{ inputs.lower-bound-yaml }}
-        upper-bound-yaml: ${{ inputs.upper-bound-yaml }}
-        semantic-upper-bound: ${{ inputs.semantic-upper-bound }}
-        always-pin-unstable: ${{ inputs.always-pin-unstable }}
-        output-toml: ${{ inputs.output-toml }}
-        pypi-to-conda-name-map-file: ${{ inputs.pypi-to-conda-name-map-file }}
-        pyyaml-version: ${{ inputs.pyyaml-version }}
-        toml-version: ${{ inputs.toml-version }}
-    - name: Print output toml
-      if: inputs.output-toml != 'none'
-      shell: bash -l {0}
-      run: cat ${{ inputs.output-toml }}
-    - name: Print output toml (overwrote input)
-      if: inputs.output-toml == 'none'
-      shell: bash -l {0}
-      run: cat ${{ inputs.input-toml }}
-    - name: Build
-      shell: bash -l {0}
-      run: |
-        pip install versioneer[toml]==0.29
-        python setup.py sdist bdist_wheel
-    - name: Publish distribution 📦 to PyPI
-      if: inputs.publish-to-pypi
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with: # Remove once trusted publisher works with reusable workflows
-        user: __token__  # Remove once trusted publisher works with reusable workflows
-        password: ${{ secrets.pypi_password }}  # Remove once trusted publisher works with reusable workflows
+  pyiron:
+    uses: ./.github/workflows/pyproject-release.yml
+    secrets: inherit
+    with:
+      semantic-upper-bound: 'minor'
+      lower-bound-yaml: '.ci_support/lower_bound.yml'


### PR DESCRIPTION
The workflow now directly references a local pyproject-release configuration, enhancing clarity and maintainability.