### PR TITLE
Attach per-atom velocities to trajectory frames (+ unit fix, seed guard)

### DIFF
--- a/pyiron_workflow_lammps/engine.py
+++ b/pyiron_workflow_lammps/engine.py
@@ -197,10 +197,12 @@ class LammpsEngine:
         elif self.mode == "md":
             # MD run: velocities & thermostat/integrator
             md = self.EngineInput
+            # seed=None would be written literally as 'None' into LAMMPS commands.
+            seed = md.seed if md.seed is not None else 12345
             T0 = md.initial_temperature or md.temperature
             # Velocity init
             lines.append(
-                f"velocity all create {T0} {md.seed} mom yes rot yes dist gaussian"
+                f"velocity all create {T0} {seed} mom yes rot yes dist gaussian"
             )
             # Thermostat/integrator logic
             if md.mode == "NVE":
@@ -217,7 +219,7 @@ class LammpsEngine:
                     )
                 elif md.thermostat == "andersen":
                     lines.append(
-                        f"fix 1 all langevin {md.temperature} {md.temperature} {md.thermostat_time_constant} {md.seed}"
+                        f"fix 1 all langevin {md.temperature} {md.temperature} {md.thermostat_time_constant} {seed}"
                     )
                     lines.append("fix 2 all nve")
                 elif md.thermostat == "temp/rescale":
@@ -232,7 +234,7 @@ class LammpsEngine:
                 elif md.thermostat == "langevin":
                     lines.append(
                         f"fix 1 all langevin {md.temperature} {md.temperature} "
-                        f"{md.thermostat_time_constant} {md.seed}"
+                        f"{md.thermostat_time_constant} {seed}"
                     )
                     lines.append("fix 2 all nve")
                 else:

--- a/pyiron_workflow_lammps/lammps.py
+++ b/pyiron_workflow_lammps/lammps.py
@@ -244,7 +244,11 @@ def arrays_to_ase_atoms(
 
     atoms = Atoms(symbols=species_lists[-1], positions=pos, cell=cell, pbc=pbc)
     if velocities is not None:
-        atoms.set_velocities(np.asarray(velocities))
+        from ase import units as _u
+
+        # pyiron_lammps reports velocities in Å/fs; ASE Atoms use Å/(ASE time unit),
+        # so convert (else get_temperature() is ~1/units.fs**2 ≈ 103.6x too low).
+        atoms.set_velocities(np.asarray(velocities) / _u.fs)
     return atoms
 
 

--- a/pyiron_workflow_lammps/lammps.py
+++ b/pyiron_workflow_lammps/lammps.py
@@ -119,14 +119,21 @@ def parse_LammpsOutput(
             lammps_dump_filepath=os.path.join(working_directory, dump_out_file_name),
         )
         # Walk the per-step pyiron_lammps_output and build trajectory + finals.
+        # Attach per-atom velocities when present so each trajectory frame carries
+        # momenta (needed for kinetic temperature in coexistence analyses).
+        generic_traj = pyiron_lammps_output["generic"]
+        velocities_traj = generic_traj.get("velocities")
         atoms_list = []
-        for i in range(len(pyiron_lammps_output["generic"]["cells"])):
+        for i in range(len(generic_traj["cells"])):
             atoms_list.append(
                 arrays_to_ase_atoms(
-                    cells=pyiron_lammps_output["generic"]["cells"][i],
-                    positions=pyiron_lammps_output["generic"]["positions"][i],
-                    indices=pyiron_lammps_output["generic"]["indices"][i],
+                    cells=generic_traj["cells"][i],
+                    positions=generic_traj["positions"][i],
+                    indices=generic_traj["indices"][i],
                     species_lists=species_lists,
+                    velocities=(
+                        velocities_traj[i] if velocities_traj is not None else None
+                    ),
                 )
             )
 
@@ -219,9 +226,13 @@ def arrays_to_ase_atoms(
     indices: np.ndarray,  # (n_frames, n_atoms)
     species_lists: list[list[str]],  # e.g. {0:'Fe',1:'C'} or {1:'Fe',2:'C'}
     pbc: bool = True,
+    velocities: np.ndarray | None = None,  # (n_atoms, 3), optional per-atom velocities
 ) -> Atoms:
     """
     Convert the final frame of LAMMPS‐style arrays into an ASE Atoms.
+
+    If ``velocities`` is given, attach them so the frame carries momenta (used by
+    kinetic-temperature analyses of MD trajectories).
 
     Raises KeyError if any type in `indices` isn't a key in `species_map`.
     """
@@ -231,7 +242,10 @@ def arrays_to_ase_atoms(
     pos = positions
     types = indices
 
-    return Atoms(symbols=species_lists[-1], positions=pos, cell=cell, pbc=pbc)
+    atoms = Atoms(symbols=species_lists[-1], positions=pos, cell=cell, pbc=pbc)
+    if velocities is not None:
+        atoms.set_velocities(np.asarray(velocities))
+    return atoms
 
 
 @pwf.as_macro_node("lammps_output")

--- a/tests/unit/test_velocity_capture.py
+++ b/tests/unit/test_velocity_capture.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ase import units
 
 from pyiron_workflow_lammps.lammps import arrays_to_ase_atoms
 
@@ -8,7 +9,7 @@ def test_arrays_to_ase_atoms_attaches_velocities():
     positions = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
     cells = np.eye(3) * 5.0
     indices = np.array([1, 1])
-    velocities = np.array([[0.1, 0.0, 0.0], [0.0, 0.2, 0.0]])
+    velocities = np.array([[0.1, 0.0, 0.0], [0.0, 0.2, 0.0]])  # pyiron units (Å/fs)
     atoms = arrays_to_ase_atoms(
         cells=cells,
         positions=positions,
@@ -18,7 +19,8 @@ def test_arrays_to_ase_atoms_attaches_velocities():
         velocities=velocities,
     )
     assert atoms.get_velocities() is not None
-    assert np.allclose(atoms.get_velocities(), velocities)
+    # stored in ASE velocity units = (Å/fs) / units.fs
+    assert np.allclose(atoms.get_velocities(), velocities / units.fs)
 
 
 def test_arrays_to_ase_atoms_without_velocities_is_zero():

--- a/tests/unit/test_velocity_capture.py
+++ b/tests/unit/test_velocity_capture.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from pyiron_workflow_lammps.lammps import arrays_to_ase_atoms
+
+
+def test_arrays_to_ase_atoms_attaches_velocities():
+    species_lists = [["Al", "Al"]]
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    cells = np.eye(3) * 5.0
+    indices = np.array([1, 1])
+    velocities = np.array([[0.1, 0.0, 0.0], [0.0, 0.2, 0.0]])
+    atoms = arrays_to_ase_atoms(
+        cells=cells,
+        positions=positions,
+        indices=indices,
+        species_lists=species_lists,
+        pbc=True,
+        velocities=velocities,
+    )
+    assert atoms.get_velocities() is not None
+    assert np.allclose(atoms.get_velocities(), velocities)
+
+
+def test_arrays_to_ase_atoms_without_velocities_is_zero():
+    atoms = arrays_to_ase_atoms(
+        cells=np.eye(3) * 5.0,
+        positions=np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        indices=np.array([1, 1]),
+        species_lists=[["Al", "Al"]],
+        pbc=True,
+    )
+    assert np.allclose(atoms.get_velocities(), 0.0)


### PR DESCRIPTION
## Summary
Attaches per-atom **velocities** to the trajectory `Atoms` frames produced by `parse_LammpsOutput`, so `EngineOutput.structures` carry momenta. This lets MD analyses recover kinetic temperature from a LAMMPS trajectory (e.g. the melting-point coexistence method in `pyiron_workflow_atomistics`).

## Changes
- `arrays_to_ase_atoms` gains an optional `velocities` argument and sets them on the `Atoms` (converting pyiron units Å/fs → ASE velocity units via `/units.fs`, else `get_temperature()` is ~103.6× too low). `pyiron_lammps` already parses the dump velocities; they were simply being dropped.
- `parse_LammpsOutput` threads the parsed `generic["velocities"]` through per frame.
- MD script builder: guard `seed=None` so it is not written literally as `"None"` into the `velocity`/`langevin` commands.
- Unit test for the velocity attachment + conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)